### PR TITLE
Extend to OTP 23 and fix warning typos

### DIFF
--- a/src/rebar_erl_vsn_prv.erl
+++ b/src/rebar_erl_vsn_prv.erl
@@ -36,7 +36,6 @@ do(State) ->
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
-
 version() ->
     parse_vsn(rebar_api:get_arch()).
 
@@ -50,18 +49,23 @@ parse_vsn(Vsn) ->
 enumerate(V) ->
     enumerate(V, []).
 
--define(HEAD_VSN, 21).
+-define(HEAD_VSN, 23).
 
 -spec enumerate({pos_integer(), non_neg_integer()}, [{d, atom()}]) -> [{d, atom()}].
 
 enumerate({V, VSub}, Acc) when V > ?HEAD_VSN orelse
                                (V =:= ?HEAD_VSN andalso VSub > 0) ->
     rebar_api:warn("The erlang version ~p.~p is newer then the latest version "
-                   "known to rebar_erl_vsn (~p). Features introduced between "
+                   "known to rebar_erl_vsn (~p). Features introduced "
                    "after ~p will not have flags.", [V, VSub, ?HEAD_VSN, ?HEAD_VSN]),
     enumerate({?HEAD_VSN, 0}, Acc);
+
 enumerate({?HEAD_VSN, 0}, Acc) ->
-    enumerate({20, 0}, [{d, '21.0'} | Acc]);
+    enumerate({22, 3}, [{d, '23.0'} | Acc]);
+enumerate({22, 0}, Acc) ->
+    enumerate({21, 3}, [{d, '22.0'} | Acc]);
+enumerate({21, 0}, Acc) ->
+    enumerate({20, 3}, [{d, '21.0'} | Acc]);
 enumerate({20, 0}, Acc) ->
     enumerate({19, 3}, [{d, '20.0'} | Acc]);
 enumerate({19, 0}, Acc) ->


### PR DESCRIPTION
Problems to solve:
* Emits a warning for OTP 22 *every frickin' time*
* There's a typo/grammar issue in the warning text.

Solutions:
* Fix the warning text
* Extend the HEAD_VSN to 23.